### PR TITLE
not so simple simple memory monitor

### DIFF
--- a/miq_server_leak_discovery/simple_memory_monitor.rb
+++ b/miq_server_leak_discovery/simple_memory_monitor.rb
@@ -1,6 +1,26 @@
 require 'sys-proctable'
 
+# comas at thousands marker
+def delimit(number)
+  number.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+end
+
+old_memory = nil     # previous value of memory
+old_memory_count = 1 # number of times this has been the same value
+value = nil          # value to display
+
 loop do
-  puts Sys::ProcTable.ps(ARGV[0].to_i).rss
+  new_memory = Sys::ProcTable.ps(ARGV[0].to_i).rss
+  if old_memory != new_memory
+    value = "#{delimit(new_memory)}#{old_memory ? " (𝛥#{delimit(new_memory - old_memory)})" : ""}"
+
+    old_memory_count = 1
+    old_memory = new_memory
+
+    print "\n#{value}"
+  else
+    old_memory_count +=1
+    print "\r#{value} x#{old_memory_count}"
+  end
   sleep 5
 end


### PR DESCRIPTION
I was having trouble determining the deltas of running the simple memory monitor
also, it was writing too many lines on my screen.

(I was running this a bunch because I had thought I found an issue with the require reproducer - only to find out it was an issue with my ruby version)

anyway.

this is the new output:

```
11,657,216 x2
11,677,696 (𝛥20,480)
11,706,368 (𝛥28,672) x2
11,710,464 (𝛥4,096)
11,726,848 (𝛥16,384) x6
11,759,616 (𝛥32,768) x6
```