### PR TITLE
Add bisect_gemfile_parser script

### DIFF
--- a/miq_bisect_gemfile_parser/README.md
+++ b/miq_bisect_gemfile_parser/README.md
@@ -1,0 +1,106 @@
+Troubleshooting
+---------------
+
+> Q.  I am getting errors trying to run `bin/rake update:ui`.  A bunch of stuff
+> about `graphql` and junk.  HALP!
+
+This (unfortunately is a bit of a common problem that isn't solved by
+`bisect_gemfile_parser` in the slightest.
+
+Things that have worked for me in the past (YMMV) is running the following
+(regardless of error):
+
+```console
+$ rm bundler.d/bisect.rb
+$ git checkout master
+$ bin/update
+$ git checkout -
+$ bin/bisect_gemfile_parser
+$ bin/bundle update
+$ bin/rake update:ui
+```
+
+Instead of running `bin/update` alone.  What the above does is at least toss
+some `packs` into the `public/packs` directory so that you have something for
+Rails' javascript tags to resolve to, and then hopefully you have a way of
+requesting the page you need without relying heavily on the javascript assets.
+
+I personally use `benchmark` command `manageiq-performance` to hit a specific
+route:
+
+```console
+$ bundle exec miqperf benchmark /route/you/want/to/hit
+```
+
+Setup instructions found here: https://github.com/ManageIQ/manageiq-performance
+
+There is a good chance that the login page will still function doing this
+method, and if the page hits an error in the controller, then the assets are
+not going to be a problem.
+
+More so, if you are hitting an API route, the assets won't matter, so you can
+just run the above command with the `--api` flag:
+
+```console
+$ bundle exec miqperf benchmark --api /api/route/you/want/to/hit
+```
+
+
+> Q. I am getting gem dependency resolution errors!  HALP!!1!
+
+Unfortunately, this is where you have to get your hands dirty and resolve the
+conflict yourself.  Also, you can yell at the dev that caused this later (I
+give you permission), because it is definitely frustrating.
+
+So the issue here usually is that some dependency in X repo got updated, but
+the same dependency in Y repo is locked at a different version, and a PR to fix
+the issue was then created in between the SHA you are currently at and the time
+that issue was resolved with a PR.
+
+The easiest way to resolve the conflict is sometimes to simply remove the
+dependency from the `Gemfile` by commenting it out.  This is an example of that
+kind of error that I resolved using this method:
+
+
+```console
+$ bin/bundle update
+Fetching https://github.com/ManageIQ/handsoap.git
+...
+Fetching https://github.com/ManageIQ/manageiq-gems-pending.git
+Fetching gem metadata from https://rubygems.org/..........
+Fetching version metadata from https://rubygems.org/...
+Fetching dependency metadata from https://rubygems.org/..
+Resolving dependencies.........................
+Bundler could not find compatible versions for gem "faraday":
+  In Gemfile:
+    manageiq-providers-google x86_64-darwin-15 was resolved to 0.1.0, which depends on
+      google-api-client (= 0.8.6) x86_64-darwin-15 was resolved to 0.8.6, which depends on
+        googleauth (~> 0.3) x86_64-darwin-15 was resolved to 0.6.2, which depends on
+          faraday (~> 0.12)
+
+    manageiq-providers-kubernetes was resolved to 0.1.0, which depends on
+      prometheus-alert-buffer-client (~> 0.2.0) x86_64-darwin-15 was resolved to 0.2.0, which depends on
+        faraday (~> 0.9.2)
+
+Bundler could not find compatible versions for gem "rbvmomi":
+  In Gemfile:
+    manageiq-providers-vmware was resolved to 0.1.0, which depends on
+      rbvmomi (~> 1.11.3)
+
+    manageiq-providers-vmware was resolved to 0.1.0, which depends on
+      vmware_web_service (~> 0.2.6) was resolved to 0.2.11, which depends on
+        rbvmomi (~> 1.12.0)
+```
+
+For this, I just commented out both `manageiq-providers-google` and
+`manageiq-providers-vmware` in the `Gemfile` directly, since I didn't need them
+for what I was testing.  If this is a `manageiq_plugin` gem, then make sure you
+are also removing it from the `bundler.d/bisect.rb` file so that doesn't break
+`bundle update`.
+
+The above assumes the plugin in question isn't needed for you to confirm your
+bug.  If it is, then you might have to do some tweaks in the Gemfile directly
+to lock versions of the offending gems.  For the above to fix `rbvmomi`, you
+might be able to explicitly set it to something that works for both
+`vmware_web_service` and `manageiq-providers-vmware`, or explicitly define a
+version of `vmware_web_service` that doesn't have such a hard requirement.

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -76,7 +76,7 @@ base_bisect_rb_content = [
   '    allowed_in_path do',
   '      if ref.include?("@")',
   '        branch, timestamp = ref.split("@")',
-  '        git("log --format=\'%H\' --branches=#{branch} --before=#{timestamp.gsub(/[\{\}]/,"")} -n1").strip',
+  '        git("log --format=\'%H\' --branches=#{branch} --before=#{timestamp.gsub(/[\{\}]/,"")} --merges -n1").strip',
   '      else',
   '        git("rev-parse --verify #{Shellwords.shellescape(ref)}", true).strip',
   '      end',

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -87,6 +87,19 @@ base_bisect_rb_content = [
   '  end',
   'end',
   '',
+  'def bisect_gem_override(name, *args)',
+  '  if dependencies.any? && dependency = dependencies.find { |d| d.name == name }',
+  '    removed_dependency = dependencies.delete(dependency)',
+  '    if removed_dependency.source.kind_of?(Bundler::Source::Git)',
+  '      @sources.send(:source_list_for, removed_dependency.source).delete_if do |other_source|',
+  '        @sources.send(:equal_source?, removed_dependency.source, other_source)',
+  '      end',
+  '    end',
+  '',
+  '    gem name, *args',
+  '  end',
+  'end',
+  '',
   'bisect_iso_time = `git show -q --format="%ai"`.chomp',
   '# Time in "hours ago".',
   '#   example:  "100.hours.ago"',
@@ -101,7 +114,7 @@ KNOWN_REPO_CHANGES = {
 
 GemfilePluginParser.parse.each do |plugin_info|
   plugin_name = plugin_info[:name]
-  override_gem_content  = "override_gem '#{plugin_name}', "
+  override_gem_content  = "bisect_gem_override '#{plugin_name}', "
   override_gem_content << ":git => 'https://github.com/ManageIQ/#{KNOWN_REPO_CHANGES[plugin_name] || plugin_name}', "
   override_gem_content << ":ref => \"#{plugin_info[:branch] || 'master'}@{\#{bisect_time}}\""
 

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -76,7 +76,7 @@ base_bisect_rb_content = [
   '    allowed_in_path do',
   '      if ref.include?("@")',
   '        branch, timestamp = ref.split("@")',
-  '        git("log --format=\'%H\' --branches=#{branch} --before=#{timestamp.gsub(/[\{\}]/,"")} --merges -n1").strip',
+  '        git("log --format=\'%H\' --before=#{timestamp.gsub(/[\{\}]/,"")} --merges -n1 #{branch}").strip',
   '      else',
   '        git("rev-parse --verify #{Shellwords.shellescape(ref)}", true).strip',
   '      end',

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -87,8 +87,17 @@ base_bisect_rb_content = [
   ''
 ]
 
+KNOWN_REPO_CHANGES = {
+  "miq_v2v_ui"   => "miq_v2v_ui_plugin",
+  "manageiq-v2v" => "miq_v2v_ui_plugin"
+}
+
 GemfilePluginParser.parse.each do |manageiq_plugin|
-  base_bisect_rb_content << "override_gem '#{manageiq_plugin}', :git => 'https://github.com/manageiq/#{manageiq_plugin}', :ref => \"master@{\#{bisect_time}}\""
+  override_gem_content  = "override_gem '#{manageiq_plugin}', "
+  override_gem_content << ":git => 'https://github.com/ManageIQ/#{KNOWN_REPO_CHANGES[manageiq_plugin] || manageiq_plugin}', "
+  override_gem_content << ":ref => \"master@{\#{bisect_time}}\""
+
+  base_bisect_rb_content << override_gem_content
 end
 
 # puts base_bisect_rb_content.join("\n")

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -29,6 +29,8 @@
 #
 
 class GemfilePluginParser
+  GIT_URL_MATCH = /^\w+:\/\/github.com\/ManageIQ\/(manageiq-|miq).*$/.freeze
+
   class << self
     def parse
       new.tap {|i| i.instance_eval { eval File.read "Gemfile" } }
@@ -44,7 +46,7 @@ class GemfilePluginParser
 
   def gem gem_name, *args
     hash = args.pop
-    if hash and hash.is_a?(Hash) and hash[:git].to_s.include?("https://github.com/ManageIQ/manageiq-")
+    if hash and hash.is_a?(Hash) and hash[:git].to_s =~ GIT_URL_MATCH
       @manageiq_plugins << gem_name
     end
   end

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -46,8 +46,11 @@ class GemfilePluginParser
 
   def gem gem_name, *args
     hash = args.pop
-    if hash and hash.is_a?(Hash) and hash[:git].to_s =~ GIT_URL_MATCH
-      @manageiq_plugins << gem_name
+    if hash and hash.is_a?(Hash) and (hash[:git] || hash["git"]).to_s =~ GIT_URL_MATCH
+      @manageiq_plugins << {
+        :name   => gem_name,
+        :branch => (hash[:branch] || hash["branch"])
+      }
     end
   end
 
@@ -96,10 +99,11 @@ KNOWN_REPO_CHANGES = {
   "manageiq-v2v" => "miq_v2v_ui_plugin"
 }
 
-GemfilePluginParser.parse.each do |manageiq_plugin|
-  override_gem_content  = "override_gem '#{manageiq_plugin}', "
-  override_gem_content << ":git => 'https://github.com/ManageIQ/#{KNOWN_REPO_CHANGES[manageiq_plugin] || manageiq_plugin}', "
-  override_gem_content << ":ref => \"master@{\#{bisect_time}}\""
+GemfilePluginParser.parse.each do |plugin_info|
+  plugin_name = plugin_info[:name]
+  override_gem_content  = "override_gem '#{plugin_name}', "
+  override_gem_content << ":git => 'https://github.com/ManageIQ/#{KNOWN_REPO_CHANGES[plugin_name] || plugin_name}', "
+  override_gem_content << ":ref => \"#{plugin_info[:branch] || 'master'}@{\#{bisect_time}}\""
 
   base_bisect_rb_content << override_gem_content
 end

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -101,4 +101,4 @@ GemfilePluginParser.parse.each do |manageiq_plugin|
 end
 
 # puts base_bisect_rb_content.join("\n")
-File.write 'bundler.d/bisect.rb', base_bisect_rb_content.join("\n")
+File.write 'bundler.d/bisect.rb', base_bisect_rb_content.join("\n") << "\n"

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -67,6 +67,7 @@ end
 
 base_bisect_rb_content = [
   'require "shellwords"',
+  'require "time"',
   '',
   'class Bundler::Source::Git::GitProxy',
   '  private',
@@ -83,7 +84,10 @@ base_bisect_rb_content = [
   '  end',
   'end',
   '',
-  'bisect_time = `git show -q --format="%ar"`.chomp.gsub(/ /, ".")',
+  'bisect_iso_time = `git show -q --format="%ai"`.chomp',
+  '# Time in "hours ago".',
+  '#   example:  "100.hours.ago"',
+  'bisect_time = "#{(Time.now.to_i - Time.parse(bisect_iso_time).to_i) / 60 / 60}.hours.ago"',
   ''
 ]
 

--- a/miq_bisect_gemfile_parser/bisect_gemfile_parser
+++ b/miq_bisect_gemfile_parser/bisect_gemfile_parser
@@ -1,0 +1,93 @@
+#!/usr/bin/env ruby
+
+# This is a helper for running a bisect when having to deal with "point in
+# time" issues when bisecting and dealing with git-gems
+#
+# Because our Gemfile use the most recent version of the gem when running a
+# `bundle` and/or `bundle update`, when attempting to do a `git bistect`,
+# dependecies that might be causing the issue are not being checked out in a
+# fashion that represents what the state of things were in the MIQ environment
+# at the point of the checkout.
+#
+# This helper attempts to checkout a proper revision of all of the manageiq git
+# gem dependencies by checking the current revision of the gems in the
+# currently parse Gemfile, and throws a override file in the `bundler.d/`
+# directory which will set the proper overrides.
+#
+# The workflow for using this script is as follows;
+#
+#   * Start `git bisect`
+#   * Run the script
+#     - you can actually chuck this in `bin/` since it is git-ignored)
+#   * Run `bin/bundle update`
+#   * Do what you need to validate the git sha, and move on the the next commit
+#   * Repeat steps 2-4 until you are finished
+#   * Run `rm bundle.d/bisect.rb` to clean up this script (DON'T FORGET!)
+#
+# The last step is important as it will most likely mess with your your master
+# branch.
+#
+
+class GemfilePluginParser
+  class << self
+    def parse
+      new.tap {|i| i.instance_eval { eval File.read "Gemfile" } }
+         .manageiq_plugins
+    end
+  end
+
+  attr_reader :manageiq_plugins
+
+  def initialize
+    @manageiq_plugins = []
+  end
+
+  def gem gem_name, *args
+    hash = args.pop
+    if hash and hash.is_a?(Hash) and hash[:git].to_s.include?("https://github.com/ManageIQ/manageiq-")
+      @manageiq_plugins << gem_name
+    end
+  end
+
+  def __dir__
+    Dir.pwd
+  end
+  def source *args; end;
+  def eval_gemfile *args; end;
+  def group *args
+    yield if block_given?
+  end
+
+  def dependencies
+    []
+  end
+end
+
+base_bisect_rb_content = [
+  'require "shellwords"',
+  '',
+  'class Bundler::Source::Git::GitProxy',
+  '  private',
+  '',
+  '  def find_local_revision',
+  '    allowed_in_path do',
+  '      if ref.include?("@")',
+  '        branch, timestamp = ref.split("@")',
+  '        git("log --format=\'%H\' --branches=#{branch} --before=#{timestamp.gsub(/[\{\}]/,"")} -n1").strip',
+  '      else',
+  '        git("rev-parse --verify #{Shellwords.shellescape(ref)}", true).strip',
+  '      end',
+  '    end',
+  '  end',
+  'end',
+  '',
+  'bisect_time = `git show -q --format="%ar"`.chomp.gsub(/ /, ".")',
+  ''
+]
+
+GemfilePluginParser.parse.each do |manageiq_plugin|
+  base_bisect_rb_content << "override_gem '#{manageiq_plugin}', :git => 'https://github.com/manageiq/#{manageiq_plugin}', :ref => \"master@{\#{bisect_time}}\""
+end
+
+# puts base_bisect_rb_content.join("\n")
+File.write 'bundler.d/bisect.rb', base_bisect_rb_content.join("\n")


### PR DESCRIPTION
This is a helper for running a bisect when having to deal with "point in time" issues when bisecting and dealing with git-gems

Because our Gemfile use the most recent version of the gem when running a `bundle` and/or `bundle update`, when attempting to do a `git bistect`, dependecies that might be causing the issue are not being checked out in a fashion that represents what the state of things were in the MIQ environment at the point of the checkout.

This helper attempts to checkout a proper revision of all of the manageiq git gem dependencies by checking the current revision of the gems in the currently parse Gemfile, and throws a override file in the `bundler.d/` directory which will set the proper overrides.


Usage
-----

The workflow for using this script is as follows;

1. Start `git bisect`
2. Run the script
    - you can actually chuck this in `bin/` since it is git-ignored)
3. Run `bin/bundle update`
4. Do what you need to validate the git sha, and move on the the next commit
5. Repeat steps 2-4 until you are finished
6. Run `rm bundle.d/bisect.rb` to clean up this script (DON'T FORGET!)

The last step is important as it will most likely mess with your your master branch.


Example Output
--------------

Here is an example `bundle.d/bisect.rb` output for a given run:

```ruby
require "shellwords"
require "time"

class Bundler::Source::Git::GitProxy
  private

  def find_local_revision
    allowed_in_path do
      if ref.include?("@")
        branch, timestamp = ref.split("@")
        git("log --format='%H' --before=#{timestamp.gsub(/[\{\}]/,"")} --merges -n1 #{branch}").strip
      else
        git("rev-parse --verify #{Shellwords.shellescape(ref)}", true).strip
      end
    end
  end
end

bisect_iso_time = `git show -q --format="%ai"`.chomp
# Time in "hours ago".
#   example:  "100.hours.ago"
bisect_time = "#{(Time.now.to_i - Time.parse(bisect_iso_time).to_i) / 60 / 60}.hours.ago"

override_gem 'manageiq-gems-pending', :git => 'https://github.com/ManageIQ/manageiq-gems-pending', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-content', :git => 'https://github.com/ManageIQ/manageiq-content', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-providers-amazon', :git => 'https://github.com/ManageIQ/manageiq-providers-amazon', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-providers-azure', :git => 'https://github.com/ManageIQ/manageiq-providers-azure', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-providers-vmware', :git => 'https://github.com/ManageIQ/manageiq-providers-vmware', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-ui-classic', :git => 'https://github.com/ManageIQ/manageiq-ui-classic', :ref => "fine@{#{bisect_time}}"
override_gem 'manageiq-providers-lenovo', :git => 'https://github.com/ManageIQ/manageiq-providers-lenovo', :ref => "fine@{#{bisect_time}}"
```


TODO
----

* [x] Consider searching for "merge commits" only in the versus any old commit (those are the only ones that matter)
* [ ] Possibly add workflow commands for handling bistect commands, that will run both steps 2 & 3 from the above workflow
* [ ] Possibly add a `bisect_gemfile_parser cleanup` subcommand to handle the `rm bundler.d/bisect.rb` portion of things.