### PR TITLE
[WIP] Add factory_bot_remover

### DIFF
--- a/factory_bot_remover/find_and_replace
+++ b/factory_bot_remover/find_and_replace
@@ -8,45 +8,52 @@ class FindAndReplace
     :class => nil
   }
 
-  def self.run args
+  def self.run *args
     new(args).run
   end
 
   def initialize args
     @args    = args
     @opts    = DEFAULT_OPTS.dup
-    @files   = []
     parse_opts!
 
     @factory = @args.shift
     @regexp  = Regexp.new "FactoryBot.(create|build)\\(:#{@factory}(, ?|\\))"
+    @dirs    = @opts[:dirs]
+    @klass   = @opts[:class]
+    @klass ||= @factory.tr(':', '')
+                      .split('_')
+                      .map!(&:capitalize)
+                      .join
 
     validate_opts!
-    find_files!
   end
 
   def run
-    if @files
-      klass   = @opts[:class]
-      klass ||= @factory.tr(':', '')
-                        .split('_')
-                        .map!(&:capitalize)
-                        .join
+    with_files do |file, name|
+      line  = nil
+      match = false
 
-      @files.each do |file|
-        puts "replacing contents for '#{file}'..."
+      while line = file.gets
+        break if match = line =~ @regexp
+      end
 
-        contents = File.read file
+      if match
+        puts "replacing contents for '#{name}'..."
+        position = file.pos
 
+        contents = line + file.read
         contents.gsub!(@regexp) do |match|
-          result  = "#{klass}.#{$1 == 'build' ? 'new' : $1}"
+          result  = "#{@klass}.#{$1 == 'build' ? 'new' : $1}"
           result += "(" if $2 != ")"
           result
         end
-        File.write file, contents
+
+        file.rewind
+        file.truncate(position)
+        file.seek(position)
+        file.write contents
       end
-    else
-      puts "no factories found with #{factory} factories"
     end
   end
 
@@ -61,13 +68,6 @@ class FindAndReplace
       puts parser.help + "\n\n"
       raise ArgumentError, "Missing factory to replace!"
     end
-  end
-
-  def find_files!
-    dirs   = @opts[:dirs].join(' ')
-    cmd    = %Q`grep -lER "#{@regexp.source}" #{dirs}`
-
-    @files = `#{cmd}`.lines.map!(&:chomp).compact
   end
 
   def parser
@@ -95,6 +95,31 @@ class FindAndReplace
       end
     end
   end
+
+  # Finds files in specified directories
+  #
+  # Assumes `@dirs` is a `spec/` dir
+  #
+  # Skips over:
+  #
+  #   - directories (duh)
+  #   - files in subdirectories of manageiq
+  #
+  # For the second, that is assumed that it is a link to or a clone of
+  # `manageiq`, and replacing those files isn't relevant.
+  #
+  def with_files
+    @dirs.each do |dir|
+      Dir["#{dir}/**/*.rb"].each do |filename|
+        next if filename.start_with? "#{dir}/manageiq/"
+        next if File.directory? filename
+
+        File.open filename, "r+" do |file|
+          yield file, filename
+        end
+      end
+    end
+  end
 end
 
-FindAndReplace.run(ARGV) if __FILE__ == $PROGRAM_NAME
+FindAndReplace.run(*ARGV) if __FILE__ == $PROGRAM_NAME

--- a/factory_bot_remover/find_and_replace
+++ b/factory_bot_remover/find_and_replace
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+opts ={
+  :dirs  => ['spec'],
+  :class => nil
+}
+
+parser = OptionParser.new do |opt|
+  opt.banner = "Usage: #{File.basename $0} [options] factory"
+
+  opt.separator ""
+  opt.separator "Scans the list of directories (default: 'spec/') for usages"
+  opt.separator "of `FactoryBot.create` or `FactoryBot.build` of the given"
+  opt.separator "factory, and replaces the contents of the file with a direct"
+  opt.separator "ActiveRecord call."
+  opt.separator ""
+  opt.separator "An optional --class can be passed, which will inform the"
+  opt.separator "script of the the replacements class should be, otherwise"
+  opt.separator "that is derived from the factory name"
+  opt.separator ""
+  opt.separator "Options"
+
+  opt.on("-c", "--class=CLASS", String, "class to replace factory with") do |klass|
+    opts[:class] = klass
+  end
+
+  opt.on("-d", "--dirs=DIRS", Array, "directories to search (default: spec)") do |dirs|
+    opts[:dirs] = dirs
+  end
+end.parse!
+
+factory = ARGV.shift
+unless factory
+  puts parser.help + "\n\n"
+  raise "Missing factory to replace!"
+end
+
+regexp = Regexp.new "FactoryBot.(create|build)\\(:#{factory}(, ?|\\))"
+dirs   = opts[:dirs].join(' ')
+cmd    = %Q`grep -lER "#{regexp.source}" #{dirs}`
+files  = `#{cmd}`
+
+if files
+  klass   = opts[:class]
+  klass ||= factory.tr(':', '')
+                   .split('_')
+                   .map(&:capitalize)
+                   .join
+
+  files.lines.map!(&:chomp).each do |file|
+    puts "replacing contents for '#{file}'..."
+
+    contents = File.read file
+
+    contents.gsub!(regexp) do |match|
+      result  = "#{klass}.#{$1 == 'build' ? 'new' : $1}"
+      result += "(" if $2 != ")"
+      result
+    end
+    File.write file, contents
+  end
+else
+  puts "no factories found with #{factory} factories"
+end

--- a/factory_bot_remover/find_and_replace
+++ b/factory_bot_remover/find_and_replace
@@ -2,65 +2,99 @@
 
 require 'optparse'
 
-opts ={
-  :dirs  => ['spec'],
-  :class => nil
-}
+class FindAndReplace
+  DEFAULT_OPTS = {
+    :dirs  => ['spec'],
+    :class => nil
+  }
 
-parser = OptionParser.new do |opt|
-  opt.banner = "Usage: #{File.basename $0} [options] factory"
-
-  opt.separator ""
-  opt.separator "Scans the list of directories (default: 'spec/') for usages"
-  opt.separator "of `FactoryBot.create` or `FactoryBot.build` of the given"
-  opt.separator "factory, and replaces the contents of the file with a direct"
-  opt.separator "ActiveRecord call."
-  opt.separator ""
-  opt.separator "An optional --class can be passed, which will inform the"
-  opt.separator "script of the the replacements class should be, otherwise"
-  opt.separator "that is derived from the factory name"
-  opt.separator ""
-  opt.separator "Options"
-
-  opt.on("-c", "--class=CLASS", String, "class to replace factory with") do |klass|
-    opts[:class] = klass
+  def self.run args
+    new(args).run
   end
 
-  opt.on("-d", "--dirs=DIRS", Array, "directories to search (default: spec)") do |dirs|
-    opts[:dirs] = dirs
+  def initialize args
+    @args    = args
+    @opts    = DEFAULT_OPTS.dup
+    @files   = []
+    parse_opts!
+
+    @factory = @args.shift
+    @regexp  = Regexp.new "FactoryBot.(create|build)\\(:#{@factory}(, ?|\\))"
+
+    validate_opts!
+    find_files!
   end
-end.parse!
 
-factory = ARGV.shift
-unless factory
-  puts parser.help + "\n\n"
-  raise "Missing factory to replace!"
-end
+  def run
+    if @files
+      klass   = @opts[:class]
+      klass ||= @factory.tr(':', '')
+                        .split('_')
+                        .map!(&:capitalize)
+                        .join
 
-regexp = Regexp.new "FactoryBot.(create|build)\\(:#{factory}(, ?|\\))"
-dirs   = opts[:dirs].join(' ')
-cmd    = %Q`grep -lER "#{regexp.source}" #{dirs}`
-files  = `#{cmd}`
+      @files.each do |file|
+        puts "replacing contents for '#{file}'..."
 
-if files
-  klass   = opts[:class]
-  klass ||= factory.tr(':', '')
-                   .split('_')
-                   .map(&:capitalize)
-                   .join
+        contents = File.read file
 
-  files.lines.map!(&:chomp).each do |file|
-    puts "replacing contents for '#{file}'..."
-
-    contents = File.read file
-
-    contents.gsub!(regexp) do |match|
-      result  = "#{klass}.#{$1 == 'build' ? 'new' : $1}"
-      result += "(" if $2 != ")"
-      result
+        contents.gsub!(@regexp) do |match|
+          result  = "#{klass}.#{$1 == 'build' ? 'new' : $1}"
+          result += "(" if $2 != ")"
+          result
+        end
+        File.write file, contents
+      end
+    else
+      puts "no factories found with #{factory} factories"
     end
-    File.write file, contents
   end
-else
-  puts "no factories found with #{factory} factories"
+
+  private
+
+  def parse_opts!
+    parser.parse! @args
+  end
+
+  def validate_opts!
+    unless @factory
+      puts parser.help + "\n\n"
+      raise ArgumentError, "Missing factory to replace!"
+    end
+  end
+
+  def find_files!
+    dirs   = @opts[:dirs].join(' ')
+    cmd    = %Q`grep -lER "#{@regexp.source}" #{dirs}`
+
+    @files = `#{cmd}`.lines.map!(&:chomp).compact
+  end
+
+  def parser
+    OptionParser.new do |opt|
+      opt.banner = "Usage: #{File.basename $0} [options] factory"
+
+      opt.separator ""
+      opt.separator "Scans the list of directories (default: 'spec/') for usages"
+      opt.separator "of `FactoryBot.create` or `FactoryBot.build` of the given"
+      opt.separator "factory, and replaces the contents of the file with a direct"
+      opt.separator "ActiveRecord call."
+      opt.separator ""
+      opt.separator "An optional --class can be passed, which will inform the"
+      opt.separator "script of the the replacements class should be, otherwise"
+      opt.separator "that is derived from the factory name"
+      opt.separator ""
+      opt.separator "Options"
+
+      opt.on("-c", "--class=CLASS", String, "class to replace factory with") do |klass|
+        @opts[:class] = klass
+      end
+
+      opt.on("-d", "--dirs=DIRS", Array, "directories to search (default: spec)") do |dirs|
+        @opts[:dirs] = dirs
+      end
+    end
+  end
 end
+
+FindAndReplace.run(ARGV) if __FILE__ == $PROGRAM_NAME

--- a/factory_bot_remover/find_and_replace
+++ b/factory_bot_remover/find_and_replace
@@ -8,9 +8,13 @@ class FindAndReplace
     :class => nil
   }
 
+  BASE_REGEXP  = /FactoryBot.(create|build)(_list)?\([[:space:]]?/
+
   def self.run *args
     new(args).run
   end
+
+  attr_accessor :factory, :klass
 
   def initialize args
     @args    = args
@@ -18,7 +22,7 @@ class FindAndReplace
     parse_opts!
 
     @factory = @args.shift
-    @regexp  = Regexp.new "FactoryBot.(create|build)\\(:#{@factory}(, ?|\\))"
+    @regexp  = Regexp.new "#{BASE_REGEXP.source}:#{@factory}(, ?|\\))"
     @dirs    = @opts[:dirs]
     @klass   = @opts[:class]
     @klass ||= @factory.tr(':', '')
@@ -37,17 +41,21 @@ class FindAndReplace
 
       while line = file.gets
         break if match = line =~ @regexp
+
+        # Check if factory definition starts on next line
+        line += file.gets.to_s
+        break if match = line =~ @regexp
       end
 
       if match
         puts "replacing contents for '#{name}'..."
         files_updated += 1
-        position = file.pos
+        position       = file.pos - line.size
 
         contents = line + file.read
         contents.gsub!(@regexp) do |match|
           result  = "#{@klass}.#{$1 == 'build' ? 'new' : $1}"
-          result += "(" if $2 != ")"
+          result += "(" if $3 != ")"
           result
         end
 

--- a/factory_bot_remover/find_and_replace
+++ b/factory_bot_remover/find_and_replace
@@ -30,6 +30,7 @@ class FindAndReplace
   end
 
   def run
+    files_updated = 0
     with_files do |file, name|
       line  = nil
       match = false
@@ -40,6 +41,7 @@ class FindAndReplace
 
       if match
         puts "replacing contents for '#{name}'..."
+        files_updated += 1
         position = file.pos
 
         contents = line + file.read
@@ -55,6 +57,8 @@ class FindAndReplace
         file.write contents
       end
     end
+
+    files_updated
   end
 
   private

--- a/factory_bot_remover/replace_all
+++ b/factory_bot_remover/replace_all
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+class ReplaceAll
+  DEFAULT_OPTS = {
+    :dir       => "manageiq",
+    :commit    => 'c79a3b40',
+    :factories => nil,
+    :git_cmds  => [],
+    :repos     => nil
+  }
+
+  def self.run *args
+    new(args).run
+  end
+
+  def initialize args
+    @args      = args
+    @opts      = DEFAULT_OPTS.dup
+
+    parse_opts!
+
+    @commit    = @opts[:commit]
+    @dir       = @opts[:dir]
+    @git_cmds  = @opts[:git_cmds]
+    @factories = @opts[:factories] || find_relevant_factories
+    @repos     = @opts[:repos]     || find_manageiq_repos
+  end
+
+  def run
+    # puts @git_cmds
+    if @git_cmds.empty?
+      replace_all!
+    else
+      run_git_cmds_on_all_repos!
+    end
+  end
+
+  def replace_all!
+    load File.expand_path "find_and_replace", __dir__
+    
+    # puts @factories.count
+    # puts @repos
+
+    checkout_branches
+
+    @factories.each do |factory|
+      puts "===> processing #{factory}..."
+
+      @repos.each do |repo|
+        replacer     = FindAndReplace.new ["--dirs", "#{repo}/spec", factory]
+        replacements = replacer.run 
+
+        if replacements > 0
+          commit_changes repo, replacer
+        end
+      end
+    end
+  end
+
+  def run_git_cmds_on_all_repos!
+    gcmds = @git_cmds.map do |git_cmd|
+      git_cmd.gsub(/^git\s*/, '')
+    end
+
+    @repos.each do |repo|
+      `#{gcmds.map { |gcmd| "git -C #{repo} #{gcmd}" }.join "; "}`
+    end
+  end
+
+  private
+
+  CLEANUP_REGEXP = /^(-  factory :|-FactoryGirl.define { factory :)/
+  def find_relevant_factories
+    `git -C #{@dir} show #{@commit}`.lines
+      .grep(/factory :.*$/)
+      .map!    { |str| str.sub!(CLEANUP_REGEXP, '').to_s[/^\w*/] }
+      .reject! { |str| str.nil? || str == "" || str == "firewall_rule" }
+  end
+
+  MIQ_GLOBS = %w[
+    manageiq
+    manageiq-api
+    manageiq-{v2v-,}ui-*
+    manageiq-graphql
+    manageiq-providers-*
+  ]
+  def find_manageiq_repos
+    Dir[*MIQ_GLOBS].select do |dir|
+      %w[.git spec].all? {|subdir| File.directory? "#{dir}/#{subdir}" }
+    end
+  end
+
+  BRANCH = "remove_factory_calls_without_factories"
+  def checkout_branches
+    @repos.each do |repo|
+      `git -C #{repo} checkout -b #{BRANCH} || git -C #{repo} checkout -b #{BRANCH}`
+    end
+  end
+
+  def commit_changes repo, replacer
+    puts "committing changes..."
+
+    commit_msg = <<-MSG.gsub(/ {6}/, '').lines.map(&:chomp).compact
+      Update usages of factory :#{replacer.factory}
+
+      Favor .new or .create with #{replacer.klass} instead
+    MSG
+
+    # puts "git -C #{repo} commit -avm #{commit_msg.map(&:inspect).join(' -m ')}"
+    `git -C #{repo} commit -avm #{commit_msg.map(&:inspect).join(' -m ')}`
+  end
+
+  def parse_opts!
+    parser.parse! @args
+  end
+
+  def parser
+    OptionParser.new do |opt|
+      opt.banner = "Usage: #{File.basename $0} [options]"
+
+      opt.separator ""
+      opt.separator "Checks c79a3b40 in `manageiq` for the factory types being"
+      opt.separator "removed, then for each type, does a find an replace in all"
+      opt.separator "of the repos defined"
+      opt.separator ""
+      opt.separator "Options"
+
+      opt.on("-c", "--commit=SHA", String, "Commit SHA which factories were removed") do |sha|
+        @opts[:commit] = sha
+      end
+
+      opt.on("-d", "--dir=DIR", String, "relative directory to manageiq repo") do |dir|
+        @opts[:dir] = dir
+      end
+
+      opt.on("-f", "--factories=NAMES", Array, "Optional factory names to replace (default: all)") do |factories|
+        @opts[:factories] = factories
+      end
+
+      opt.on("--git-cmd=GIT_CMD", String, "git command(s) to run on all repos") do |git_cmd|
+        @opts[:git_cmds] << git_cmd
+      end
+
+      opt.on("-r", "--repos=REPOS", Array, "Project directories to search") do |repos|
+        @opts[:repos] = repos
+      end
+    end
+  end
+end
+
+ReplaceAll.run(*ARGV) if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
This script is really a one time script for searching for files that use `FactoryBot.build` or `FactoryBot.create`, and replace them with the straight `ActiveRecord` equivalents.

Might add some more functionality to this to auto commit as well, and search all repos at a time.  We will see...