### PR TITLE
Updates to `vmdb_db_restore`

### DIFF
--- a/vmdb_db_restore
+++ b/vmdb_db_restore
@@ -44,7 +44,7 @@ OptionParser.new do |opt|
   end
 
   opt.on "-r", "--region=REGION",         Integer, "Set ENV['REGION'] (def: NONE)" do |region|
-    @options[:region] = region
+    @options[:region] = region.to_s
   end
 
   opt.on       "--rails52",               String,  "Assume Rails v5.2" do

--- a/vmdb_db_restore
+++ b/vmdb_db_restore
@@ -144,7 +144,7 @@ def migrate_database
 end
 
 run_cmd "Bundle update",                 %Q[bin/bundle update]
-run_cmd "Creating database"     cmd_env, migrate_database
+run_cmd "Creating database",    cmd_env, migrate_database
 run_cmd "Dumping data into #{db_name}",  %Q[pg_restore -v -U root -j 4 -d #{db_name} "#{db_dump_file}"]
 run_cmd "Migrating database",   cmd_env, %Q[bin/rake db:migrate]
 run_cmd "Fixing database auth",          %Q[bundle exec tools/fix_auth.rb --v2 --invalid bogus --db #{db_name}]

--- a/vmdb_db_restore
+++ b/vmdb_db_restore
@@ -55,16 +55,16 @@ OptionParser.new do |opt|
     @options[:update] = yes_no
   end
 
-  # opt.on("-v", "--[no-]verbose", "Enable/Disable ActiveRecord logging to STDOUT") do |val|
-  #   options[:verbose] = val
-  # end
+  opt.on       "--[no-]verbose",                   "Verbose mode"  do |yes_no|
+    @options[:verbose] = yes_no
+  end
 end.parse!
 
-db_dump_file = ARGV.shift
-raise ArgumentError, "DB_DUMP is required!"             unless db_dump_file
+@db_dump_file = ARGV.shift
+raise ArgumentError, "DB_DUMP is required!"             unless @db_dump_file
 
-db_name = @options[:db_name]
-raise ArgumentError, "A new database name is required!" unless db_name
+@db_name = @options[:db_name]
+raise ArgumentError, "A new database name is required!" unless @db_name
 
 require 'open3'
 require 'io/console'
@@ -86,7 +86,7 @@ trap "INT" do puts; puts "Interrupt..."; exit 1 end
 #
 # Runs a command in a new process, and prints a message and spinner while it is
 # running.
-def run_cmd msg, env_or_cmd, cmd = nil
+def run_cmd msg, env_or_cmd, cmd = nil, &block
   STDIN.echo = false
   cmd_env = cmd.nil? ? {} : env_or_cmd
   cmd     = env_or_cmd if cmd.nil?
@@ -96,7 +96,8 @@ def run_cmd msg, env_or_cmd, cmd = nil
   outdata = []
   status  = nil
   spinner = 0
-  print "\e[0;1;49m====> \e[1;32;49m#{msg}\e[0m    "
+  verbose = " (#{cmd_env.inspect} #{cmd})" if @options[:verbose]
+  print "\e[0;1;49m====> \e[1;32;49m#{msg}#{verbose}\e[0m    "
 
   Open3.popen2e cmd_env, cmd do |stdin, out, cmd_thr|
     # Spinner Thread
@@ -123,8 +124,15 @@ def run_cmd msg, env_or_cmd, cmd = nil
       end
     end
 
+    # Input thread
+    input = Thread.new do
+      yield stdin
+      stdin.close
+    end if block_given?
+
     status = cmd_thr.value
     spin.join
+    input.join if input
     output.join
   end
 
@@ -143,10 +151,48 @@ def migrate_database
   cmd
 end
 
+def import_db
+  if File.open(@db_dump_file, "rb") { |f| f.readpartial(5) } == "PGDMP"
+    run_cmd "Dumping data into #{@db_name}",  %Q[pg_restore -v -U root -j 4 -d #{@db_name} "#{@db_dump_file}"]
+  else
+    stdin_proc = Proc.new do |stdin|
+      require 'zlib'
+
+      io = File.open(@db_dump_file)
+
+      # try zlib
+      begin
+        io = Zlib::GzipReader.new(io)
+      rescue Zlib::GzipFile::Error
+      end
+
+      skip_count = 0
+      connect_line_regxp = /^\\connect [^\s]+/
+
+      # check the first 1000 lines to find any `\connect DBNAME` lines.  Keep
+      # track of the most recent one.
+      io.each_line.with_index do |line, index|
+        skip_count = index if line.match connect_line_regxp
+        break if index > 1000
+      end
+
+      # start from the beginning again, incase we skipped nothing
+      io.rewind
+
+      # don't pass anything before the `skip_count` to psql, and after that,
+      # forward all of the lines on to `psql`
+      io.each_line.with_index do |line, index|
+        index <= skip_count ? next : stdin.puts(line)
+      end
+    end
+    run_cmd "Dumping data into #{@db_name}", {}, %Q[psql -U root -d #{@db_name}], &stdin_proc
+  end
+end
+
 run_cmd "Bundle update",                 %Q[bin/bundle update]
 run_cmd "Creating database",    cmd_env, migrate_database
-run_cmd "Dumping data into #{db_name}",  %Q[pg_restore -v -U root -j 4 -d #{db_name} "#{db_dump_file}"]
+import_db
 run_cmd "Migrating database",   cmd_env, %Q[bin/rake db:migrate]
-run_cmd "Fixing database auth",          %Q[bundle exec tools/fix_auth.rb --v2 --invalid bogus --db #{db_name}]
+run_cmd "Fixing database auth",          %Q[bundle exec tools/fix_auth.rb --v2 --invalid bogus --db #{@db_name}]
 run_cmd "Update dependencies",  cmd_env, %Q[bin/update]
 run_cmd "Update default auth",  cmd_env, %Q[bin/rails runner 'User.where(:userid => "admin").each {|u| u.update_attribute :password, "smartvm"}']

--- a/vmdb_db_restore
+++ b/vmdb_db_restore
@@ -137,7 +137,7 @@ end
 
 def migrate_database
   cmd  = "bin/rake"
-  cmd += " db:environment:set"  if @options[:rails52]
+  cmd += " db:environment:set"  if @options[:rails52] && @options[:drop]
   cmd += " db:drop"             if @options[:drop]
   cmd += " db:create"
   cmd

--- a/vmdb_db_restore
+++ b/vmdb_db_restore
@@ -135,7 +135,7 @@ ensure
   STDIN.echo = true
 end
 
-def migrate_database cmd_env
+def migrate_database
   cmd  = "bin/rake"
   cmd += " db:environment:set"  if @options[:rails52]
   cmd += " db:drop"             if @options[:drop]


### PR DESCRIPTION
- Fixes `--region` when passing it as an `ENV`
- Fixes syntax error (missing comma)
- Fixes uneeded arg for `.migrate_database` method
- Fixes `.migrate_database` not working with `--rails52` (only apply `db:environment:set` with `--drop` as well)
- Allow working with "textual style" DB dumps (see commit message for details)